### PR TITLE
Allow *.notion.site URLs

### DIFF
--- a/src/infra/usecases/to-page-id/url-validator.ts
+++ b/src/infra/usecases/to-page-id/url-validator.ts
@@ -14,6 +14,6 @@ export class UrlValidor implements Validation {
   }
 
   private _isNotionPargeUrl(): boolean {
-    return /^http(s?):\/\/(w{3}.)?notion.so\/((\w)+?\/)?(\w|-){32,}/g.test(this._url);
+    return /^http(s?):\/\/[\w\-]*\.notion.s(o|ite)\/((\w)+?\/)?(\w|-){32,}/g.test(this._url);
   }
 }

--- a/src/infra/usecases/to-page-id/url-validator.ts
+++ b/src/infra/usecases/to-page-id/url-validator.ts
@@ -14,6 +14,6 @@ export class UrlValidor implements Validation {
   }
 
   private _isNotionPargeUrl(): boolean {
-    return /^http(s?):\/\/[\w\-]*\.notion.s(o|ite)\/((\w)+?\/)?(\w|-){32,}/g.test(this._url);
+    return /^http(s?):\/\/((w{3}.)?notion.so|[\w\-]*\.notion\.site)\/((\w)+?\/)?(\w|-){32,}/g.test(this._url);
   }
 }


### PR DESCRIPTION
Hi Alexandre,

This change allows to use either `[www.]notion.so` or `adjective-noun-123.notion.site` URL styles used by Notion.
You may test the regex here : https://regex101.com/r/OFkPBO/1
All the tests pass. 

Closes #28 
It should also fix https://github.com/asnunes/notion-page-to-html-api/issues/2

Best regards,
Stéphane
