### PR TITLE
docs: fixed the build command documentation in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ npm test
 
 Installing locally in another project:
 ````
-npm build
+npm run build
 npm pack
 ````
 Inside your project:


### PR DESCRIPTION
Hi,

The instructions to build a local version are wrong : `npm build` should be `npm run build`.

Best regards,
Stéphane