### PR TITLE
fix: 4 space code block not render correctly

### DIFF
--- a/src/__tests__/mocks/blocks.ts
+++ b/src/__tests__/mocks/blocks.ts
@@ -1270,6 +1270,25 @@ export const CODE_WITH_DECORATION = [
   },
 ];
 
+export const CODE_WITH_4_SPACES = [
+  {
+    id: '479c7b34-6c22-4f2d-b947-8f47d02b48d6',
+    type: 'code',
+    properties: { language: 'Python' },
+    format: {},
+    children: [] as Block[],
+    decorableTexts: [
+      {
+        text: `def print_pattern():
+    size = 4
+    for i in range(size):
+        print("*" * size)`,
+        decorations: [],
+      },
+    ],
+  },
+];
+
 export const QUOTE = [
   {
     id: 'e0a0cfa3-1f64-438b-ac79-95e5c7ad4565',

--- a/src/data/use-cases/blocks-to-html-converter/block-parsers/code.ts
+++ b/src/data/use-cases/blocks-to-html-converter/block-parsers/code.ts
@@ -13,7 +13,7 @@ export class CodeBlockToHtml implements ToHtml {
     const languageClass = this._language ? `class="language-${this._language}"` : '';
 
     return Promise.resolve(
-      `<pre><code ${languageClass}>${blockToInnerText(this._block).replace(/(\s{4}|\t)/g, '  ')}</code></pre>`,
+      `<pre><code ${languageClass}>${blockToInnerText(this._block).replace(/\t/g, '  ')}</code></pre>`,
     );
   }
 

--- a/src/data/use-cases/blocks-to-html-converter/blocks-to-html-converter.test.ts
+++ b/src/data/use-cases/blocks-to-html-converter/blocks-to-html-converter.test.ts
@@ -532,6 +532,19 @@ describe('#convert', () => {
         );
       });
     });
+
+    describe('When there is 4 space indent code', () => {
+      it('correctly preserve the 4 spaces and return html with pre tag and code tag inside', async () => {
+        const html = await makeSut(BlockMocks.CODE_WITH_4_SPACES).convert();
+
+        expect(html).toBe(
+          `<pre><code class="language-python">def print_pattern():
+    size = 4
+    for i in range(size):
+        print("*" * size)</code></pre>`
+        )
+      })
+    })
   });
 
   describe('When single quote block is given', () => {


### PR DESCRIPTION
`\s{4}` also match `\n`
I just remove it so it will suitable for languages with 4-space like Python or Go.