### PR TITLE
fix image url loading from Notion after they changed the Response

### DIFF
--- a/src/utils/use-cases/http-get/node-http-get.ts
+++ b/src/utils/use-cases/http-get/node-http-get.ts
@@ -30,7 +30,7 @@ export class NodeHttpGetClient implements HttpGetClient {
             return resolve({
               status: res.statusCode || 200,
               headers: res.headers as Record<string, any>,
-              data: JSON.parse(stringData),
+              data: JSON.stringify(res.headers),
             });
           });
         })


### PR DESCRIPTION
Formerly: image url were saved in an object "stringData"

Now: Notion passes image urls directly in headers.location

This commit solves the resulting bug.