### PR TITLE
fix: page cover fetching - follow redirects

### DIFF
--- a/src/utils/use-cases/http-get/node-http-get.ts
+++ b/src/utils/use-cases/http-get/node-http-get.ts
@@ -18,6 +18,9 @@ export class NodeHttpGetClient implements HttpGetClient {
             const format = res.headers['content-type'] || 'image/jpeg';
 
             if (res.statusCode === 403) throw new ForbiddenError('could not fetch data from url: ' + url);
+            if (res.statusCode && res.statusCode >= 300 && res.statusCode < 400 && res.headers.location) {
+              return resolve(this.get(res.headers.location));
+            }
 
             if (format.includes('image')) {
               return resolve({


### PR DESCRIPTION
Fixes https://github.com/asnunes/notion-page-to-html/issues/40

Page rendering broke because the `NodeHttpGetClient.get` function could not handle redirects. Since notion seems to have changed the domain of their user content servers, the package broke if trying to render a notion page that has a cover image.

This PR fixes the bug by checking if the status code of the response is a redirect and if so, recursively invoking `get()` again on the URL in the `location` header.

@asnunes 